### PR TITLE
Validation/trainsplit

### DIFF
--- a/models/simple_cnn.py
+++ b/models/simple_cnn.py
@@ -4,16 +4,26 @@ import torch.nn.functional as F
 class SimpleCNN(nn.Module):
     def __init__(self):
         super(SimpleCNN, self).__init__()
+        #W1
         self.conv1 = nn.Conv2d(3, 32, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(32)
+        
+        #W2
         self.conv2 = nn.Conv2d(32, 64, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(64)
+        
         self.fc1 = nn.Linear(64 * 8 * 8, 256)
         self.fc2 = nn.Linear(256, 10)
 
     def forward(self, x):
-        x = F.relu(self.conv1(x))
+        #conv1 + BN + reLU
+        x = F.relu(self.bn1(self.conv1(x)))
         x = F.max_pool2d(x, 2)
-        x = F.relu(self.conv2(x))
+        
+        #conv2 + BN + reLU
+        x = F.relu(self.bn2(self.conv2(x)))
         x = F.max_pool2d(x, 2)
+        
         x = x.view(-1, 64 * 8 * 8)
         x = F.relu(self.fc1(x))
         x = self.fc2(x)

--- a/test.py
+++ b/test.py
@@ -6,6 +6,9 @@ from utils import imshow
 import torchvision
 
 def main():
+    # setting up GPU as default device
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print("Using device:", device)
     # Data tranformation
     transform = transforms.Compose([
         transforms.ToTensor(),
@@ -17,16 +20,24 @@ def main():
     testloader = torch.utils.data.DataLoader(testset, batch_size=64, shuffle=False)
 
     # Read model
-    model = SimpleCNN()
+    model = SimpleCNN().to(device)
     model.load_state_dict(torch.load("model.pth"))
     model.eval()
 
     # Displaying sample images with predictions
     dataiter = iter(testloader)
     images, labels = next(dataiter)
+    
+    images = images.to(device)
+    labels = labels.to(device)
+    
     outputs = model(images)
     _, predicted = torch.max(outputs, 1)
-
+    
+    #transfering back to CPU for visualization purposes
+    im_cpu = images.cpu()
+    imshow(torchvision.utils.make_grid(im_cpu))
+    
     for i in range(5):
         imshow(torchvision.utils.make_grid(images))
 

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import torch
 import torchvision.transforms as transforms
 from torchvision.datasets import CIFAR10
+from torch.utils.data import DataLoader
 from models.simple_cnn import SimpleCNN
 from utils import imshow
 import torchvision
@@ -17,11 +18,11 @@ def main():
 
     # load testing data
     testset = CIFAR10(root='./data', train=False, download=True, transform=transform)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=64, shuffle=False)
+    testloader = DataLoader(testset, batch_size=64, shuffle=False)
 
     # Read model
     model = SimpleCNN().to(device)
-    model.load_state_dict(torch.load("model.pth"))
+    model.load_state_dict(torch.load("best_model.pth", map_location=device))
     model.eval()
 
     # Displaying sample images with predictions
@@ -37,12 +38,8 @@ def main():
     #transfering back to CPU for visualization purposes
     im_cpu = images.cpu()
     imshow(torchvision.utils.make_grid(im_cpu))
-    
-    for i in range(5):
-        imshow(torchvision.utils.make_grid(images))
-
-    print("Rzeczywiste etykiety(test):", labels.numpy())
-    print("Przewidywane etykiety(test):", predicted.numpy())
+    print("Rzeczywiste etykiety(test):", labels.cpu().numpy())
+    print("Przewidywane etykiety(test):", predicted.cpu().numpy())
 
     # Model testing
     correct = 0
@@ -50,12 +47,17 @@ def main():
 
     with torch.no_grad():
         for inputs, labels in testloader:
+            inputs = inputs.to(device)
+            labels = labels.to(device)
             outputs = model(inputs)
             _, predicted = torch.max(outputs, 1)
             total += labels.size(0)
             correct += (predicted == labels).sum().item()
+            
+    accuracy = 100.0 * correct / total
+    print(f"Dokładność na zbiorze testowym: {accuracy:.2f}%")
 
-    print(f"Dokładność: {100 * correct / total:.2f}%")
+    
 
 if __name__ == "__main__":
     main()

--- a/train.py
+++ b/train.py
@@ -6,6 +6,10 @@ from models.simple_cnn import SimpleCNN
 from utils import imshow
 
 def main():
+    # setting up GPU as default device
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print("Using device:", device)
+    
     # Data transformation
     transform = transforms.Compose([
         transforms.RandomHorizontalFlip(),
@@ -26,14 +30,18 @@ def main():
 
     # model init
     print("------init model  ------")
-    model = SimpleCNN()
+    model = SimpleCNN().to(device) #transfering to GPU
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     print("------init model - done ------")
     # Train
-    for epoch in range(10):  # Liczba epok
+    for epoch in range(20):  # added to 20 - testing to see if model would overfit
         running_loss = 0.0
         for inputs, labels in trainloader:
+            #transfering to GPU
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+            
             optimizer.zero_grad()
             outputs = model(inputs)
             loss = criterion(outputs, labels)

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import matplotlib
-# matplotlib.use('TkAgg')
+matplotlib.use('TkAgg')
 # matplotlib.use('Agg')
-matplotlib.use('MacOSX')
+#matplotlib.use('MacOSX')
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
Added: 
train.py - splitting the set to train and validation (45000/5000), storing the best outcomes after training - monitoring val_loss and val_accuracy after each epoch to detect potential overfitting instead of immediately using the test set
test.py - deleted the range(5) loop from closing the visualization, making the testing on the best model that was being saved during training to get a proper final acc score.